### PR TITLE
feat(loadfile): request directory contents via new iframe API

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -50,6 +50,12 @@ function App(): JSX.Element {
 		null
 	)
 
+	// The most recent directory-contents request we issued. Responses whose
+	// requestId does not match are stale (e.g. from a previous root) and
+	// ignored to prevent overwriting fresh state with older data.
+	const activeRequestIdRef = useRef<string | null>(null)
+	const requestCounterRef = useRef<number>(0)
+
 	const [showModal, setShowModal] = useState<boolean>(false)
 	const [form, setForm] = useState<string>("")
 
@@ -180,9 +186,80 @@ function App(): JSX.Element {
 			const result = event.data
 
 			switch (result.type) {
-				case "send-directory-contents":
+				case "send-directory-contents": {
+					// Root-change broadcast: carries directoryPath / directoryName
+					// but ships an empty nodes tree since ouroboros #106. Preserve
+					// the metadata, then request the recursive tree separately.
 					setDirectoryData(result)
+
+					const nextPath: string | null =
+						result?.data?.directoryPath ?? null
+					if (!nextPath) {
+						activeRequestIdRef.current = null
+						break
+					}
+
+					const requestId = `loadfile-${++requestCounterRef.current}`
+					activeRequestIdRef.current = requestId
+
+					parent.postMessage(
+						{
+							type: "request-directory-contents",
+							data: {
+								path: nextPath,
+								recursive: true,
+								requestId,
+							},
+						},
+						"*"
+					)
 					break
+				}
+				case "send-directory-contents-response": {
+					// Late responses from a previous root arrive after we've moved
+					// on; drop them. requestId is nullable in the schema, so a
+					// missing id also fails to match.
+					if (result?.data?.requestId !== activeRequestIdRef.current) {
+						break
+					}
+
+					const responsePath: string = result.data.path
+					const responseNodes: NodeChildren =
+						result.data.nodes ?? {}
+					const errorCode: string | undefined = result.data.error?.code
+
+					// denied / not-found / internal → treat as empty tree; the
+					// user's "no files" state is already the right rendering.
+					// limit → partial nodes present; render what we got.
+					// (The truncated flag could surface a hint later; keep the
+					// current diff focused on unblocking discovery.)
+					const nextNodes: NodeChildren =
+						errorCode === "denied" ||
+						errorCode === "not-found" ||
+						errorCode === "internal"
+							? {}
+							: responseNodes
+
+					if (errorCode === "internal") {
+						console.error(
+							"request-directory-contents failed:",
+							result.data.error
+						)
+					}
+
+					setDirectoryData((prev) => {
+						if (!prev) return prev
+						if (prev.data.directoryPath !== responsePath) return prev
+						return {
+							...prev,
+							data: {
+								...prev.data,
+								nodes: nextNodes,
+							},
+						}
+					})
+					break
+				}
 				case "send-neuroglancer-json":
 				case "read-file-response":
 					if (viewerMode === "ngrefactor") {


### PR DESCRIPTION
Closes #9.

Depends on **ouroboros #114 (merged)** which added the request/response iframe API.

## Problem

Since ouroboros #106, `send-directory-contents` arrives with `nodes: {}`. The plugin's LoadFile modal renders an empty list — `Object.values(directoryData.data.nodes).map(...)` sees nothing.

## What changed

Wire up the new API in `src/App/index.tsx`:

- On each `send-directory-contents` (root change), dispatch a `request-directory-contents` with `recursive: true` and a monotonic `requestId` (\`loadfile-N\`).
- Track the active `requestId` in a ref; drop late responses whose id doesn't match, so a response for a previous root can't clobber the current tree.
- On `send-directory-contents-response`, merge `data.nodes` back into `directoryData` so LoadFile's existing tree renderer works again without changes.
- Guard the merge with a `data.path === current directoryPath` check — belt-and-suspenders against the same out-of-order case.
- Handle `error.code`:
  - `denied` / `not-found` / `internal` → empty tree (matches the existing \"no files\" rendering).
  - `internal` also logs via `console.error`.
  - `limit` with `truncated: true` → render the partial nodes the response carries. The truncation hint UI is deferred as a follow-up so this diff stays surgical.

LoadFile itself is unchanged.

## Verify

- `npx tsc -b` — clean (typecheck passes).
- `npm run build` — clean.
- `npm run lint` — pre-existing lint errors in the repo (288, mostly `@ts-nocheck` and `no-explicit-any` in NG viewer code, unrelated to this change). No new errors introduced (identical count on \`main\` vs. this branch).

**Manual UI smoke against a running Ouroboros not performed here** — no display on the automation host. Reviewer checklist for a live test:

1. Open Ouroboros, load the neuroglancer plugin, and Open Folder → a small directory.
2. LoadFile modal should populate with the folder tree.
3. Change root folder → tree updates to the new root.
4. Rapid root changes → no stale-tree flicker (thanks to requestId matching).
5. Load against a folder large enough to hit the enumeration cap → partial tree renders, no crash.

## Not changed

- Message-handling structure elsewhere (\`send-neuroglancer-json\`, \`read-file-response\`, save flow) is untouched.
- Autoseg plugin doesn't need this — it doesn't use parent-window directory messaging.

## Followup

If desired, surface \`error.truncated: true\` in the LoadFile UI (e.g., \"showing partial tree\") — separate small PR.