### PR TITLE
Release Neuroglancer plugin v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ To test in Ouroboros, run Ouroboros in development mode as well, and use the `Te
 
 The current production pin for Ouroboros package builds is:
 
-- tag: `v1.0.1`
-- release asset: `neuroglancer-plugin-v1.0.1.zip`
+- tag: `v1.1.0`
+- release asset: `neuroglancer-plugin-v1.1.0.zip`
 
 That asset archive root is the same layout that Ouroboros expects inside its
 plugin folder:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"index": "./index.html",
 	"dockerCompose": "./compose.yml",
 	"private": true,
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"type": "module",
 	"main": "dist/main.js",
 	"files": [


### PR DESCRIPTION
## Summary\n\nPrepare the Neuroglancer plugin v1.1.0 release.\n\n- bump the packaged plugin version to 1.1.0\n- update the documented production tag and artifact name\n- release the directory-request integration merged in #10\n\n## Verification\n\n- 
> neuroglancer-plugin@1.1.0 build:release
> npm run build && node scripts/write-release-manifest.mjs


> neuroglancer-plugin@1.1.0 build
> tsc -b && vite build

vite v5.4.21 building for production...
transforming...
✓ 74 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                   0.36 kB │ gzip:  0.24 kB
dist/ngrefactor.html                              1.46 kB │ gzip:  0.63 kB
dist/assets/main-BnIizsfc.css                     5.65 kB │ gzip:  1.59 kB
dist/assets/ngrefactor-qAppT-eh.css             101.39 kB │ gzip: 18.13 kB
dist/assets/modulepreload-polyfill-B5Qt9EMX.js    0.71 kB │ gzip:  0.40 kB
dist/assets/helpPopover-DwYPhtT7.js               1.25 kB │ gzip:  0.66 kB
dist/assets/lineMode-7QC74UV9.js                  3.36 kB │ gzip:  1.47 kB
dist/assets/rotate-CmPK6ICk.js                    4.03 kB │ gzip:  1.20 kB
dist/assets/meshControls-Dq4NKMPh.js              4.08 kB │ gzip:  1.63 kB
dist/assets/pathRide-Bzx42IZO.js                 14.72 kB │ gzip:  4.99 kB
dist/assets/main-DjQ3Bv1u.js                    156.05 kB │ gzip: 50.48 kB
dist/assets/ngrefactor-q20VfDIY.js              177.96 kB │ gzip: 50.24 kB
[vite-plugin-static-copy] Copied 5 items.
✓ built in 1.53s\n- 
> neuroglancer-plugin@1.1.0 validate:release
> node scripts/validate-release-manifest.mjs

Validated Neuroglancer release layout for v1.1.0.\n- \n\n## Existing debt\n\n
> neuroglancer-plugin@1.1.0 lint
> eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0


/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Enhancements/octoEnhancements.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
    3:15  error  'Ontology' is defined but never used                           @typescript-eslint/no-unused-vars
    4:15  error  'OntologyUI' is defined but never used                         @typescript-eslint/no-unused-vars
   13:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   75:12  error  'getSoloEntryLabel' is defined but never used                  @typescript-eslint/no-unused-vars
  103:12  error  'ensureSoloRestoreBanner' is defined but never used            @typescript-eslint/no-unused-vars
  335:20  error  '_' is assigned a value but never used                         @typescript-eslint/no-unused-vars

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Export/mipRes.ts
  128:31  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  128:68  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Export/ng-utils.ts
    3:16  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   11:23  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   51:26  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   62:41  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   62:47  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   63:16  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   64:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   94:48  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  103:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  105:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  106:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  108:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  109:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  130:83  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  133:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  144:28  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  168:46  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  196:28  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Export/scriptTemplates.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Layers/lineMode.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   90:72  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  118:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  135:35  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  152:70  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  164:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  177:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  179:70  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Layers/mute.ts
   1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   5:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  29:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  31:14  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  31:46  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  32:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  41:67  error  Empty block statement                                          no-empty
  57:65  error  Empty block statement                                          no-empty
  63:31  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  63:45  error  Empty block statement                                          no-empty
  70:69  error  Empty block statement                                          no-empty
  72:11  error  Empty block statement                                          no-empty

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Layers/muteStyle.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Ontology/core.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  100:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  101:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  102:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  103:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  161:38  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  168:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  225:34  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  241:40  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  256:34  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  276:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  287:17  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  306:31  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  307:34  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Ontology/ui.ts
    1:1    error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
    4:15   error  'Ontology' is defined but never used                           @typescript-eslint/no-unused-vars
    5:10   error  'setStoredOntologyExpansion' is defined but never used         @typescript-eslint/no-unused-vars
   10:3    error  'mutateVisibleSegments' is defined but never used              @typescript-eslint/no-unused-vars
  504:14   error  'isMatch' is never reassigned. Use 'const' instead             prefer-const
  511:23   error  'ancestorEntry' is never reassigned. Use 'const' instead       prefer-const
  652:30   error  Empty block statement                                          no-empty
  748:17   error  'idsToHighlight' is never reassigned. Use 'const' instead      prefer-const
  945:10   error  'entry' is never reassigned. Use 'const' instead               prefer-const
  966:616  error  Empty block statement                                          no-empty

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Overlay/PreviewPane.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Site/consent.ts
   9:18  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
  12:14  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
  25:32  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
  26:14  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
  28:35  error  '_args' is defined but never used               @typescript-eslint/no-unused-vars
  29:20  error  Use the rest parameters instead of 'arguments'  prefer-rest-params
  29:44  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
  32:14  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Site/copy.ts
    2:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   77:7  error  'oneSentenceHeading' is never reassigned. Use 'const' instead  prefer-const
  121:7  error  'dataHeading' is never reassigned. Use 'const' instead         prefer-const

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Site/download.ts
  23:31  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  42:31  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Site/shell.ts
   1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  21:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  61:37  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/alignPlane.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
    9:24  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   15:10  error  'clamp' is defined but never used                              @typescript-eslint/no-unused-vars
  111:33  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  121:42  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  121:76  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  126:23  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  127:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  134:44  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  134:71  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  139:32  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  146:45  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  151:48  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  156:29  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  164:21  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  189:45  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  199:29  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  207:35  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  212:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  329:9   error  'up' is never reassigned. Use 'const' instead                  prefer-const
  418:7   error  'up' is never reassigned. Use 'const' instead                  prefer-const
  424:37  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  435:39  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  459:65  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/dynamicMenu.ts
     1:1    error  Do not use "@ts-nocheck" because it alters compilation errors      @typescript-eslint/ban-ts-comment
    12:3    error  'initializeSidePanelControls' is defined but never used            @typescript-eslint/no-unused-vars
    58:10   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   107:33   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   109:18   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   150:5    error  'featureModules' is assigned a value but never used                @typescript-eslint/no-unused-vars
   181:25   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   656:12   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   659:32   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   660:16   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   668:22   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   678:20   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   780:61   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   817:59   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
   907:3    error  'compressionSelectLabel' is never reassigned. Use 'const' instead  prefer-const
   924:3    error  'transposeCheckboxLabel' is never reassigned. Use 'const' instead  prefer-const
   928:3    error  'predictorCheckboxLabel' is never reassigned. Use 'const' instead  prefer-const
   950:3    error  'memoryBudgetInputLabel' is never reassigned. Use 'const' instead  prefer-const
  1001:59   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1041:3    error  'compressionSelectWhole' is never reassigned. Use 'const' instead  prefer-const
  1044:3    error  'transposeCheckboxWhole' is never reassigned. Use 'const' instead  prefer-const
  1048:3    error  'predictorCheckboxWhole' is never reassigned. Use 'const' instead  prefer-const
  1070:3    error  'memoryBudgetInputWhole' is never reassigned. Use 'const' instead  prefer-const
  1094:40   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1095:45   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1278:43   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1280:52   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1310:11   error  'size' is assigned a value but never used                          @typescript-eslint/no-unused-vars
  1311:11   error  'scale' is assigned a value but never used                         @typescript-eslint/no-unused-vars
  1320:53   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1362:38   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1365:52   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1446:34   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1446:70   error  'targetLayerName' is defined but never used                        @typescript-eslint/no-unused-vars
  1730:40   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1745:116  error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1800:79   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1809:90   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1831:27   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any
  1832:18   error  Unexpected any. Specify a different type                           @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/helpPopover.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/home.ts
   1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   6:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   7:23  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   9:44  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  13:40  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  17:37  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  75:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/meshControls.ts
   1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  11:11  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  18:17  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  97:51  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/muteLayers.ts
  4:85  error  Empty block statement  no-empty

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/pathRide.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  384:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  411:42  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  411:76  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  416:23  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  417:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  424:35  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  431:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  452:59  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  682:7   error  'controlPoints' is assigned a value but never used             @typescript-eslint/no-unused-vars

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/planeTilt.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  109:29  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  114:22  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  114:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  124:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  138:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  150:42  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  150:76  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  155:23  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  156:20  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  163:44  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  163:71  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  168:32  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  175:33  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  185:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  190:48  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  197:29  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  205:21  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  231:24  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  235:38  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  286:32  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  302:11  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  386:11  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  455:43  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  533:60  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/rotate.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  165:44  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Tools/sidePanels.ts
   1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  41:29  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Utils/storage.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Utils/url.ts
   8:45  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  51:36  error  Unnecessary escape character: \[          no-useless-escape

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Viewer/boot.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   23:45  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   39:14  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   40:21  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   42:27  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   44:40  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   46:21  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   47:32  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   48:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  177:49  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  180:48  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  181:47  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  188:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  230:37  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  230:52  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  232:24  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  256:34  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  262:23  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  317:32  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  356:17  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  357:17  error  Empty block statement                                          no-empty
  361:25  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  363:17  error  Empty block statement                                          no-empty
  367:22  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  369:17  error  Empty block statement                                          no-empty
  429:15  error  Empty block statement                                          no-empty
  473:46  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  474:45  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  625:84  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Viewer/devChunkLogs.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
   18:18  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   21:14  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   44:33  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   44:75  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  105:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  111:37  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  112:35  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  118:16  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  186:44  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  187:8   error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  252:31  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  252:71  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  254:31  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  285:34  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  289:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  293:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  294:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  297:49  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  297:98  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  298:46  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  299:24  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  303:24  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Viewer/ng.ts
    1:1   error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment
    4:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
    5:12  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
    6:38  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
    8:41  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   13:19  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   16:30  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   16:36  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   28:48  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   36:67  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   38:18  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   50:67  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   63:94  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   69:47  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   69:53  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   74:52  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   74:58  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   79:50  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   79:56  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   83:53  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   83:78  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   91:62  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   96:50  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
   96:74  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any
  117:95  error  Unexpected any. Specify a different type                       @typescript-eslint/no-explicit-any

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Viewer/rotate.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/NG/Viewer/sync.ts
  1:1  error  Do not use "@ts-nocheck" because it alters compilation errors  @typescript-eslint/ban-ts-comment

/home/dnorthover/ChengCode/neuroglancer-plugin/src/App/index.tsx
  294:5  warning  React Hook useEffect has a missing dependency: 'setEmbeddedViewerState'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

✖ 289 problems (288 errors, 1 warning)
  8 errors and 0 warnings potentially fixable with the `--fix` option. reports the repository's pre-existing imported-Neuroglancer lint backlog (288 errors and one warning); this release metadata change adds no source lint findings.