### PR TITLE
Release Neuroglancer plugin v1.1.1

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -35,8 +35,8 @@ jobs:
       contents: read
 
     env:
-      OUROBOROS_PLUGIN_RELEASE_TAG: v1.1.0-ci
-      OUROBOROS_PLUGIN_ARTIFACT: neuroglancer-plugin-v1.1.0-ci.zip
+      OUROBOROS_PLUGIN_RELEASE_TAG: v1.1.1-ci
+      OUROBOROS_PLUGIN_ARTIFACT: neuroglancer-plugin-v1.1.1-ci.zip
 
     steps:
       - name: Check out Git repository

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ responses from the first root do not replace the second tree.
 
 The current production pin for Ouroboros package builds is:
 
-- tag: `v1.1.0`
-- release asset: `neuroglancer-plugin-v1.1.0.zip`
+- tag: `v1.1.1`
+- release asset: `neuroglancer-plugin-v1.1.1.zip`
 
 That asset archive root is the same layout that Ouroboros expects inside its
 plugin folder:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "neuroglancer-plugin",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "neuroglancer-plugin",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"dependencies": {
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"index": "./index.html",
 	"dockerCompose": "./compose.yml",
 	"private": true,
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"packageManager": "npm@11.19.0",
 	"engines": {
 		"node": ">=24",


### PR DESCRIPTION
## Summary

Prepare the Neuroglancer plugin v1.1.1 release.

- bump the packaged plugin and lockfile version to 1.1.1
- update the documented production tag and artifact name
- update CI release fixtures to v1.1.1
- release the reproducible-build and directory-request regression hardening merged in #13

## Verification

- locked install with Node 24 and npm 11.19.0
- `npm test` (8 tests)
- `npm run smoke:dev`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run build:release`
- `npm run validate:release`
- `npm run validate:archive -- dist/neuroglancer-plugin-v1.1.1.zip`

The generated archive manifest reports release tag `v1.1.1`, package version
`1.1.1`, and artifact name `neuroglancer-plugin-v1.1.1.zip`.

## Post-merge

Tag the merged commit as `v1.1.1` to trigger the release workflow and publish
`neuroglancer-plugin-v1.1.1.zip`.
